### PR TITLE
Add scheduling tests

### DIFF
--- a/src/quorum/execution.py
+++ b/src/quorum/execution.py
@@ -180,6 +180,8 @@ class ExecutionThread(threading.Thread):
     def peek_work(self):
         self.work_lock.acquire()
         try:
+            if not self.work_list:
+                return None
             return self.work_list[0]
         finally:
             self.work_lock.release()
@@ -187,6 +189,8 @@ class ExecutionThread(threading.Thread):
     def pop_work(self):
         self.work_lock.acquire()
         try:
+            if not self.work_list:
+                return None
             return heapq.heappop(self.work_list)
         finally:
             self.work_lock.release()

--- a/src/quorum/execution.py
+++ b/src/quorum/execution.py
@@ -177,6 +177,27 @@ class ExecutionThread(threading.Thread):
         finally:
             self.work_lock.release()
 
+    def peek_work(self):
+        self.work_lock.acquire()
+        try:
+            return self.work_list[0]
+        finally:
+            self.work_lock.release()
+
+    def pop_work(self):
+        self.work_lock.acquire()
+        try:
+            return heapq.heappop(self.work_list)
+        finally:
+            self.work_lock.release()
+
+    def clear_work(self):
+        self.work_lock.acquire()
+        try:
+            self.work_list.clear()
+        finally:
+            self.work_lock.release()
+
 
 def background(timeout=None):
     """

--- a/src/quorum/test/execution.py
+++ b/src/quorum/test/execution.py
@@ -189,15 +189,15 @@ class WorkTest(quorum.TestCase):
 
             self.assertEqual(result, 10)
             self.assertEqual(len(recorded), 1)
-            callable_o, target_time, callback, description = recorded[0]
+            callable_o, target_time, _callback, description = recorded[0]
             self.assertEqual(target_time, 10)
             self.assertEqual(description, "dummy-work")
 
-            recorded.clear()
+            del recorded[:]
             callable_o()
 
             self.assertEqual(len(recorded), 1)
-            _, target_time, _, description = recorded[0]
+            _callable_o, target_time, _callback, description = recorded[0]
             self.assertEqual(target_time, 20)
             self.assertEqual(description, "dummy-work")
         finally:

--- a/src/quorum/test/execution.py
+++ b/src/quorum/test/execution.py
@@ -150,7 +150,7 @@ class ExecutionTest(quorum.TestCase):
         thread.insert_work(dummy, description="dummy-work")
         self.assertEqual(len(thread.work_list), 1)
 
-        _time, callable_o, callback, args, kwargs, description = thread.work_list[0]
+        _time, callable_o, callback, args, kwargs, description = thread.peek_work()
         self.assertEqual(description, "dummy-work")
 
     @quorum.secured

--- a/src/quorum/test/execution.py
+++ b/src/quorum/test/execution.py
@@ -150,7 +150,7 @@ class ExecutionTest(quorum.TestCase):
         thread.insert_work(dummy, description="dummy-work")
         self.assertEqual(len(thread.work_list), 1)
 
-        _time, callable_o, callback, args, kwargs, description = thread.peek_work()
+        _time, callable_o, _callback, _args, _kwargs, description = thread.peek_work()
         self.assertEqual(description, "dummy-work")
 
     @quorum.secured

--- a/src/quorum/test/execution.py
+++ b/src/quorum/test/execution.py
@@ -165,7 +165,14 @@ class WorkTest(quorum.TestCase):
 
         recorded = []
 
-        def custom_insert_work(callable_o, args=[], kwargs={}, target_time=None, callback=None, description=None):
+        def custom_insert_work(
+            callable_o,
+            args=[],
+            kwargs={},
+            target_time=None,
+            callback=None,
+            description=None,
+        ):
             recorded.append((callable_o, target_time, callback, description))
 
         original_insert_work = quorum.execution.insert_work
@@ -195,4 +202,3 @@ class WorkTest(quorum.TestCase):
             self.assertEqual(description, "dummy-work")
         finally:
             quorum.execution.insert_work = original_insert_work
-

--- a/src/quorum/test/execution.py
+++ b/src/quorum/test/execution.py
@@ -140,9 +140,6 @@ class ExecutionTest(quorum.TestCase):
         expected_t = calendar.timegm(expected_d.utctimetuple())
         self.assertEqual(result, expected_t)
 
-
-class WorkTest(quorum.TestCase):
-
     @quorum.secured
     def test_insert_work_description(self):
         thread = quorum.ExecutionThread()


### PR DESCRIPTION
## Summary
- add unit tests for work description on scheduler

## Testing
- `ADAPTER=tiny pytest -q -k 'not export and not httpc'`

------
https://chatgpt.com/codex/tasks/task_e_687cd1784950832896199be4bc05e337